### PR TITLE
Support emacs 29

### DIFF
--- a/popup-kill-ring.el
+++ b/popup-kill-ring.el
@@ -4,8 +4,8 @@
 
 ;; Author: HAMANO Kiyoto <khiker.mail+elisp@gmail.com>
 ;; Keywords: popup, kill-ring, pos-tip
-;; Package-Requires: ((pos-tip "0.4.5") (popup "0.5"))
-;; Homepage: https://code.launchpad.net/~khiker/+junk/popup-kill-ring
+;; Package-Requires: ((pos-tip "0.4.6") (popup "0.5.9"))
+;; Homepage: https://github.com/waymondo/popup-kill-ring
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -50,14 +50,18 @@
 ;;; Tested:
 ;;
 ;; * Emacs
-;;   * 24.4
+;;   * 29.1
 ;; * popup.el
-;;   * 0.5.2
+;;   * 0.5.9
 ;; * pos-tip.el
 ;;   * 0.4.6
 ;;
 
 ;;; ChangeLog:
+;;
+;; * 1.0.0
+;;   Updated to work with lexically-scoped popup changes.
+;;   Removed functions and vars related to popup-kill-ring-kill-ring-show-func.
 ;;
 ;; * 0.2.11 (2015/03/22)
 ;;   Minor fixes (apply diffs of EmacsWiki, use defcustom and so on ...)
@@ -149,10 +153,10 @@
 
 (require 'popup)
 (require 'pos-tip)
+(require 'seq)
 
 (eval-when-compile
   (require 'cl-lib))
-
 
 ;;; Variables:
 
@@ -161,10 +165,8 @@
   :group  'convenience
   :prefix "popup-kill-ring-")
 
-
-(defconst popup-kill-ring-version "0.2.11"
+(defconst popup-kill-ring-version "1.0.0"
   "Version of `popup-kill-ring'")
-
 
 (defcustom popup-kill-ring-popup-width 30
   "Width of popup item."
@@ -179,25 +181,6 @@
 (defcustom popup-kill-ring-popup-margin-right 2
   "Width of `popup-menu*' margin-right."
   :type 'integer
-  :group 'popup-kill-ring)
-
-(defcustom popup-kill-ring-timeout 1
-  "Time of displaying `pos-tip-show' help tooltip."
-  :type 'integer
-  :group 'popup-kill-ring)
-
-(defcustom popup-kill-ring-kill-ring-show-func 'popup-kill-ring-pos-tip-show
-  "Function of displaying the contents of `kill-ring'.
-This function requires two arguments `str' and `pos'.
-`str' is string of displaying. `pos' is point of displaying.
-Default value is `popup-kill-ring-pos-tip-show'."
-  :type 'function
-  :group 'popup-kill-ring)
-
-(defcustom popup-kill-ring-pos-tip-color nil
-  "Face for `pos-tip-show'.
-See docstring of `pos-tip-show'."
-  :type 'face
   :group 'popup-kill-ring)
 
 (defcustom popup-kill-ring-interactive-insert nil
@@ -235,256 +218,123 @@ Nil means that item does not be truncate."
   :type 'boolean
   :group 'popup-kill-ring)
 
-;; key setting for `popup-menu*'.
 (defvar popup-kill-ring-keymap
   (let ((keymap (make-sparse-keymap)))
     (set-keymap-parent keymap popup-menu-keymap)
-    (define-key keymap (kbd "RET")     'popup-kill-ring-select)
-    (define-key keymap (kbd "C-n")     'popup-kill-ring-next)
-    (define-key keymap (kbd "C-p")     'popup-kill-ring-previous)
-    (define-key keymap (kbd "<down>")  'popup-kill-ring-next)
-    (define-key keymap (kbd "<up>")    'popup-kill-ring-previous)
-    (define-key keymap (kbd "C-f")     'popup-kill-ring-current)
-    (define-key keymap (kbd "C-b")     'popup-kill-ring-hide)
-    (define-key keymap (kbd "<right>") 'popup-kill-ring-current)
-    (define-key keymap (kbd "<left>")  'popup-kill-ring-hide)
-    keymap)
-    "A keymap for `popup-menu*' of `popup-kill-ring'.")
+    (define-key keymap "\C-n" 'popup-kill-ring-next)
+    (define-key keymap "\C-p" 'popup-kill-ring-previous)
+    keymap))
 
-(defvar popup-kill-ring-buffer-point-hash nil
-  "The hash of buffer(key) and list of point(value).
-key is buffer name.
-value is list of points (start . end).
-this is internal variable for `popup-kill-ring'.")
+(defvar popup-kill-ring--interactive-region-start nil)
+(defvar popup-kill-ring--interactive-region-end nil)
 
-
+;;;###autoload
 ;;; Functions:
 
+
 (defun popup-kill-ring ()
-  "Interactively insert selected item from `key-ring' by `popup.el'
-and `pos-tip.el'"
   (interactive)
   (cond
    ((minibufferp)
     (yank))
-   (t (let* ((index 0)
-             (summary 0)
-             (kring (let (l p-max)
-                      (dolist (i kill-ring)
-                        (when (or (null popup-kill-ring-item-min-width)
-                                  (>= (length i)
-                                      popup-kill-ring-item-min-width))
-                          (setq l
-                                (cons
-                                 (propertize
-                                  (with-temp-buffer
-                                    (erase-buffer)
-                                    (insert (replace-regexp-in-string
-                                             "[ \t]+" " "
-                                             (replace-regexp-in-string
-                                              "\n" " " i)))
-                                    (cond
-                                     ((and popup-kill-ring-item-size-max
-                                           (>= (point-max)
-                                               popup-kill-ring-item-size-max))
-                                      (setq p-max
-                                            popup-kill-ring-item-size-max))
-                                     (t
-                                      (setq p-max (point-max))))
-                                    (buffer-substring-no-properties
-                                     (point-min) p-max))
-                                  'index index
-                                  'summary (concat "("
-                                                   (int-to-string summary)
-                                                   ")"))
-                                 l))
-                          (setq summary (1+ summary)))
-                        (setq index (1+ index)))
-                      (when l
-                        (nreverse l))))
-             (popup-kill-ring-buffer-point-hash (make-hash-table :test 'equal))
-             num item)
+   (t (let ((kring (popup-kill-ring--convert-kill-ring)))
         (when popup-kill-ring-interactive-insert
-          ;; TODO: (nth 0 kill-ring) != (nth 0 kring).
-          ;; The kring discards item that lenght shorter than
-          ;; `popup-kill-ring-item-min-width'.
-          ;; So, The following code should be fixed.
-          (popup-kill-ring-insert-item 0))
-        ;; always execute `pos-tip-hide'
-        ;; (The case that the item was selected.
-        ;;  the case that it was typed `C-g'.)
+          (setq popup-kill-ring--interactive-region-start (point))
+          (popup-kill-ring--interactive-insert-item (nth 0 kring)))
         (unwind-protect
-            (progn (setq item (popup-menu* kring
-                                           :width popup-kill-ring-popup-width
-                                           :keymap popup-kill-ring-keymap
-                                           :margin-left popup-kill-ring-popup-margin-left
-                                           :margin-right popup-kill-ring-popup-margin-right
-                                           :scroll-bar t
-                                           :isearch popup-kill-ring-isearch))
-                   (when item
-                     (setq num (popup-kill-ring-get-index item))
-                     (when num
-                       (let ((kill-ring-item (nth num kill-ring)))
-                         (when popup-kill-ring-last-used-move-first
-                           (setq kill-ring
-                                 (nconc (reverse (last (reverse kill-ring) num))
-                                        (cdr (nthcdr num kill-ring))))
-                           (push kill-ring-item kill-ring))
-                         (insert kill-ring-item)))))
+            (let ((item (popup-menu* kring
+                                     :keymap popup-kill-ring-keymap
+                                     :width popup-kill-ring-popup-width
+                                     :margin-left popup-kill-ring-popup-margin-left
+                                     :margin-right popup-kill-ring-popup-margin-right
+                                     :scrollbar t
+                                     :isearch popup-kill-ring-isearch
+                                     :symbol 'popup-kill-ring)))
+              (when (and item (not popup-kill-ring-interactive-insert)) (insert item)))
           (pos-tip-hide)
-          ;; If `C-g' was typed, clear the inserted string.
           (when (and popup-kill-ring-interactive-insert
                      (numberp last-input-event)
-                     (= last-input-event (string-to-char (kbd "C-g"))))
-            (popup-kill-ring-clear-inserted)))))))
+                     (= last-input-event 7))
+            (popup-kill-ring--clear-interactive-insert)
+          ))))))
 
-(defun popup-kill-ring-pos-tip-show (str pos)
-  (when (display-graphic-p)
-    (pos-tip-show str popup-kill-ring-pos-tip-color pos nil 0 nil nil nil 0)))
+(defun popup-kill-ring--get-current-popup ()
+  (seq-find (lambda (p) (eq (popup-symbol p) 'popup-kill-ring)) popup-instances))
 
-(defun popup-kill-ring-select ()
-  (interactive)
-  (let* ((m (with-no-warnings menu))
-         (num (popup-cursor m))
-         (lst (popup-list m))
-         (item (popup-item-value-or-self (nth num lst)))
-         (p (gethash (buffer-name) popup-kill-ring-buffer-point-hash)))
-    (when popup-kill-ring-interactive-insert
-      (goto-char (cdr (gethash (buffer-name)
-                               popup-kill-ring-buffer-point-hash)))
-      (when (and p (listp p))
-        ;; After the `popup-isearch', these is the case that diffrence selected
-        ;; item of `popup-menu*' from inserted string to `current-buffer'.
-        (unless (string= (buffer-substring (car p) (cdr p)) item)
-          (delete-region (car p) (cdr p))
-          (cl-return item)))
-      (cl-return))
-    (cl-return item)))
+(defun popup-kill-ring--get-item (&optional offset)
+  (let ((current-popup (popup-kill-ring--get-current-popup)))
+    (nth (+ (or offset 0) (popup-cursor current-popup)) current-popup)))
+
+(defun popup-kill-ring--convert-kill-ring ()
+  (let ((index -1)
+        (kring (if popup-kill-ring-last-used-move-first (reverse kill-ring) kill-ring)))
+    (mapcar
+     (lambda (killed-item)
+       (setq index (1+ index))
+       (propertize
+        (with-temp-buffer
+          (erase-buffer)
+          (insert (replace-regexp-in-string
+                   "[ \t]+" " "
+                   (replace-regexp-in-string
+                    "\n" " " killed-item)))
+          (cond
+           ((and popup-kill-ring-item-size-max
+                (>= (point-max) popup-kill-ring-item-size-max))
+           (setq p-max popup-kill-ring-item-size-max))
+           (t (setq p-max (point-max))))
+          (buffer-substring-no-properties (point-min) p-max))
+        'index index
+        'summary (concat "(" (int-to-string index) ")")))
+     kring)))
 
 (defun popup-kill-ring-next ()
   (interactive)
-  ;; Variable `menu' is contents of popup.
-  ;; See: `popup-menu-event-loop'
-  (let* ((m (with-no-warnings menu))
-         (num (1+ (popup-cursor m)))
-         (lst (popup-list m))
-         (len (length lst))
-         (offset (popup-offset m))
-         item)
-    (when (>= num len)
-      (setq num 0))
-    (when popup-kill-ring-interactive-insert
-      (popup-kill-ring-clear-inserted))
-    (setq item (popup-x-to-string (nth num lst)))
-    ;; Variable `num' is converted from the index of `popup-menu*'
-    ;; to the index of `kill-ring'.
-    (setq num (popup-kill-ring-get-index item))
-    ;; Since the every time drawing is very heavy,
-    ;; `pos-tip' help is displays when timeout occured.
-    (with-timeout
-        (popup-kill-ring-timeout
-         (progn
-           ;; display selected item of kill-ring by `pos-tip-show'
-           (when num
-             (funcall popup-kill-ring-kill-ring-show-func
-                      (format "%s" (nth num kill-ring))
-                      (popup-child-point m offset)))))
-      (pos-tip-hide)
-      (popup-next m)
+  (let* ((current-popup (popup-kill-ring--get-current-popup))
+         (current-index (popup-cursor current-popup))
+         (max-index (1- (length (popup-list current-popup))))
+         (next-index (if (>= (1+ current-index) max-index) max-index (1+ current-index))))
+    (when (not (eq current-index next-index))
       (when popup-kill-ring-interactive-insert
-        (popup-kill-ring-insert-item num))
-      ;; wait for timeout
-      (sit-for (+ 0.5 popup-kill-ring-timeout)))))
-
-(defun popup-kill-ring-current ()
-  (interactive)
-  ;; Variable `menu' is contents of popup.
-  ;; See: `popup-menu-event-loop'
-  (let* ((m (with-no-warnings menu))
-         (num (popup-cursor m))
-         (lst (popup-list m))
-         (len (length lst))
-         (offset (popup-offset m))
-         item)
-    ;; display selected item of kill-ring by `pos-tip-show'
-    (setq item (popup-x-to-string (nth num lst)))
-    (setq num (popup-kill-ring-get-index item))
-    (when num
-      (funcall popup-kill-ring-kill-ring-show-func
-               (format "%s" (nth num kill-ring))
-               (popup-child-point m offset)))))
+        (let ((current-item (nth current-index (popup-list current-popup)))
+              (next-item (nth next-index (popup-list current-popup))))
+          (popup-kill-ring--clear-interactive-insert)
+          (popup-kill-ring--interactive-insert-item next-item)))
+      (popup-next current-popup))))
 
 (defun popup-kill-ring-previous ()
   (interactive)
-  ;; Variable `menu' is contents of popup.
-  ;; See: `popup-menu-event-loop'
-  (let* ((m (with-no-warnings menu))
-         (num (1- (popup-cursor m)))
-         (lst (popup-list m))
-         (len (length lst))
-         (offset (popup-offset m))
-         item)
-    (when popup-kill-ring-interactive-insert
-      (popup-kill-ring-clear-inserted))
-    (when (< num 0)
-      (setq num (1- len)))
-    (setq item (popup-x-to-string (nth num lst)))
-    ;; Variable `num' is converted from the index of `popup-menu*'
-    ;; to the index of `kill-ring'.
-    (setq num (popup-kill-ring-get-index item))
-    ;; Since the every time drawing is very heavy,
-    ;; `pos-tip' help is displays when timeout occured.
-    (with-timeout
-        (popup-kill-ring-timeout
-         (progn
-           ;; display selected item of kill-ring by `pos-tip-show'
-           (when num
-             (funcall popup-kill-ring-kill-ring-show-func
-                      (format "%s" (nth num kill-ring))
-                      (popup-child-point m offset)))))
-      (pos-tip-hide)
-      (popup-previous m)
+  (let* ((current-popup (popup-kill-ring--get-current-popup))
+         (current-index (popup-cursor current-popup))
+         (prev-index (if (<= (1- current-index) 0) 0 (1- current-index))))
+    (when (not (eq current-index prev-index))
       (when popup-kill-ring-interactive-insert
-        (popup-kill-ring-insert-item num))
-      ;; wait for timeout
-      (sit-for (+ 0.5 popup-kill-ring-timeout)))))
+        (let ((current-item (nth current-index (popup-list current-popup)))
+              (previous-item (nth prev-index (popup-list current-popup))))
+          (popup-kill-ring--clear-interactive-insert)
+          (popup-kill-ring--interactive-insert-item previous-item)))
+      (popup-previous current-popup))))
 
-(defun popup-kill-ring-hide ()
-  (interactive)
-  (pos-tip-hide))
+(defun popup-kill-ring--interactive-insert-item (item)
+  (let* ((start (point))
+         (end (+ start (length item)))
+         ol)
+    (setq popup-kill-ring--interactive-region-end end)
+    (unwind-protect
+        (with-timeout (1.0 (if ol (delete-overlay)))
+          (insert item)
+          (recenter)
+          (setq ol (make-overlay start end))
+          (overlay-put ol 'face popup-kill-ring-interactive-insert-face)
+          (sit-for 0.15))
+      (if ol (delete-overlay ol)))))
 
-(defun popup-kill-ring-get-index (item)
-  (with-temp-buffer
-    (erase-buffer)
-    (insert item)
-    (get-text-property (point-min) 'index)))
-
-(defun popup-kill-ring-insert-item (num)
-    (let* ((item (format "%s" (nth num kill-ring)))
-           (s (point))
-           (e (+ s (length item)))
-           ol)
-      (puthash (buffer-name) (cons s e)
-               popup-kill-ring-buffer-point-hash)
-      (unwind-protect
-          (with-timeout (1.0 (if ol (delete-overlay ol)))
-            (insert item)
-            (recenter)
-            (setq ol (make-overlay s e))
-            (overlay-put ol 'face popup-kill-ring-interactive-insert-face)
-            (sit-for 0.5))
-        (if ol (delete-overlay ol)))))
-
-(defun popup-kill-ring-clear-inserted ()
+(defun popup-kill-ring--clear-interactive-insert ()
   (when popup-kill-ring-interactive-insert
-    (let* ((p (gethash (buffer-name)
-                       popup-kill-ring-buffer-point-hash)))
-      (when (and p (listp p))
-        (delete-region (car p) (cdr p))
-        (goto-char (car p))))))
+    (delete-region popup-kill-ring--interactive-region-start popup-kill-ring--interactive-region-end)
+    (goto-char popup-kill-ring--interactive-region-start)))
 
 (provide 'popup-kill-ring)
-
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil

--- a/popup-kill-ring.el
+++ b/popup-kill-ring.el
@@ -1,13 +1,11 @@
 ;;; popup-kill-ring.el --- interactively insert item from kill-ring
 
-;; Copyright (C) 2010  khiker
+;; Copyright (C) 2010-2015  HAMANO Kiyoto
 
-;; Author: khiker <khiker.mail+elisp@gmail.com>
-;; URL: https://github.com/waymondo/popup-kill-ring
+;; Author: HAMANO Kiyoto <khiker.mail+elisp@gmail.com>
 ;; Keywords: popup, kill-ring, pos-tip
-;; Package-Requires: ((popup "0.4") (pos-tip "0.4"))
-
-;; MELPA compatibility added by Justin Talbott
+;; Package-Requires: ((pos-tip "0.4.5") (popup "0.5"))
+;; Homepage: https://code.launchpad.net/~khiker/+junk/popup-kill-ring
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -52,15 +50,25 @@
 ;;; Tested:
 ;;
 ;; * Emacs
-;;   * 23.1
-;;   * 24.0.50
+;;   * 24.4
 ;; * popup.el
-;;   * 0.4
+;;   * 0.5.2
 ;; * pos-tip.el
-;;   * 0.4.0
+;;   * 0.4.6
 ;;
 
 ;;; ChangeLog:
+;;
+;; * 0.2.11 (2015/03/22)
+;;   Minor fixes (apply diffs of EmacsWiki, use defcustom and so on ...)
+;;
+;; * 0.2.10 (2015/03/22)
+;;   To check whether the pos-tip can use, use `display-graphic-p'
+;;   instead of (eq window-system 'x). (This bug was reported by
+;;   id:ganaware. Thank you.)
+;;
+;; * 0.2.9 (2014/11/25)
+;;   Use cl-lib instead of cl.
 ;;
 ;; * 0.2.8 (2011/06/10)
 ;;   Added the new variable `popup-kill-ring-last-used-move-first'.  If
@@ -141,75 +149,105 @@
 
 (require 'popup)
 (require 'pos-tip)
-;; for `return' macro
+
 (eval-when-compile
-  (require 'cl))
+  (require 'cl-lib))
 
 
 ;;; Variables:
 
-(defconst popup-kill-ring-version "0.2.8"
+(defgroup popup-kill-ring nil
+  "interactively insert item from kill-ring"
+  :group  'convenience
+  :prefix "popup-kill-ring-")
+
+
+(defconst popup-kill-ring-version "0.2.11"
   "Version of `popup-kill-ring'")
 
 
-(defvar popup-kill-ring-popup-width 30
-  "*Width of popup item.")
+(defcustom popup-kill-ring-popup-width 30
+  "Width of popup item."
+  :type  'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-popup-margin-left 2
-  "*Width of `popup-menu*' margin-left.")
+(defcustom popup-kill-ring-popup-margin-left 2
+  "Width of `popup-menu*' margin-left."
+  :type 'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-popup-margin-right 2
-  "*Width of `popup-menu*' margin-right.")
+(defcustom popup-kill-ring-popup-margin-right 2
+  "Width of `popup-menu*' margin-right."
+  :type 'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-timeout 1
-  "*Time of displaying `pos-tip-show' help tooltip.")
+(defcustom popup-kill-ring-timeout 1
+  "Time of displaying `pos-tip-show' help tooltip."
+  :type 'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-kill-ring-show-func 'popup-kill-ring-pos-tip-show
-  "*Function of displaying the contents of `kill-ring'.
+(defcustom popup-kill-ring-kill-ring-show-func 'popup-kill-ring-pos-tip-show
+  "Function of displaying the contents of `kill-ring'.
 This function requires two arguments `str' and `pos'.
 `str' is string of displaying. `pos' is point of displaying.
-Default value is `popup-kill-ring-pos-tip-show'.")
+Default value is `popup-kill-ring-pos-tip-show'."
+  :type 'function
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-pos-tip-color nil
-  "*Face for `pos-tip-show'.
-See docstring of `pos-tip-show'.")
+(defcustom popup-kill-ring-pos-tip-color nil
+  "Face for `pos-tip-show'.
+See docstring of `pos-tip-show'."
+  :type 'face
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-interactive-insert nil
-  "*Non-nil means that insert selected item of `popup-menu*' interactively.")
+(defcustom popup-kill-ring-interactive-insert nil
+  "Non-nil means that insert selected item of `popup-menu*' interactively."
+  :type 'boolean
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-isearch t
-  "*Non-nil means that passes `t' to `isearch' option of `popup-menu*'")
+(defcustom popup-kill-ring-isearch t
+  "Non-nil means that passes `t' to `isearch' option of `popup-menu*'"
+  :type 'boolean
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-item-min-width 3
-  "*The number that shows minimum width of displaying `kill-ring' item
-of `popup-menu*'")
+(defcustom popup-kill-ring-item-min-width 3
+  "The number that shows minimum width of displaying `kill-ring' item
+of `popup-menu*'"
+  :type 'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-item-size-max nil
-  "*The number that means max each item size of `popup-menu'.
+(defcustom popup-kill-ring-item-size-max nil
+  "The number that means max each item size of `popup-menu'.
 If item size is longer than this number, it's truncated.
-Nil means that item does not be truncate.")
+Nil means that item does not be truncate."
+  :type 'integer
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-interactive-insert-face 'highlight
-  "*The face for interactively inserted string when
-`popup-kill-ring-interactive-insert' is `t'.")
+(defcustom popup-kill-ring-interactive-insert-face 'highlight
+  "The face for interactively inserted string when
+`popup-kill-ring-interactive-insert' is `t'."
+  :type 'face
+  :group 'popup-kill-ring)
 
-(defvar popup-kill-ring-last-used-move-first t
-  "*Non-nil means that last selected `kill-ring' item comes first of
-`kill-ring'.")
+(defcustom popup-kill-ring-last-used-move-first t
+  "Non-nil means that last selected `kill-ring' item comes first of
+`kill-ring'."
+  :type 'boolean
+  :group 'popup-kill-ring)
 
 ;; key setting for `popup-menu*'.
 (defvar popup-kill-ring-keymap
   (let ((keymap (make-sparse-keymap)))
     (set-keymap-parent keymap popup-menu-keymap)
-    (define-key keymap "\r" 'popup-kill-ring-select)
-    (define-key keymap "\C-n" 'popup-kill-ring-next)
-    (define-key keymap "\C-p" 'popup-kill-ring-previous)
-    (define-key keymap [down] 'popup-kill-ring-next)
-    (define-key keymap [up] 'popup-kill-ring-previous)
-    (define-key keymap "\C-f" 'popup-kill-ring-current)
-    (define-key keymap "\C-b" 'popup-kill-ring-hide)
-    (define-key keymap [right] 'popup-kill-ring-current)
-    (define-key keymap [left] 'popup-kill-ring-hide)
+    (define-key keymap (kbd "RET")     'popup-kill-ring-select)
+    (define-key keymap (kbd "C-n")     'popup-kill-ring-next)
+    (define-key keymap (kbd "C-p")     'popup-kill-ring-previous)
+    (define-key keymap (kbd "<down>")  'popup-kill-ring-next)
+    (define-key keymap (kbd "<up>")    'popup-kill-ring-previous)
+    (define-key keymap (kbd "C-f")     'popup-kill-ring-current)
+    (define-key keymap (kbd "C-b")     'popup-kill-ring-hide)
+    (define-key keymap (kbd "<right>") 'popup-kill-ring-current)
+    (define-key keymap (kbd "<left>")  'popup-kill-ring-hide)
     keymap)
     "A keymap for `popup-menu*' of `popup-kill-ring'.")
 
@@ -219,7 +257,7 @@ key is buffer name.
 value is list of points (start . end).
 this is internal variable for `popup-kill-ring'.")
 
-;;;###autoload
+
 ;;; Functions:
 
 (defun popup-kill-ring ()
@@ -294,14 +332,14 @@ and `pos-tip.el'"
                            (push kill-ring-item kill-ring))
                          (insert kill-ring-item)))))
           (pos-tip-hide)
-          ;; If `C-g' was typed, clear the inserted string. (7 is `C-g'.)
+          ;; If `C-g' was typed, clear the inserted string.
           (when (and popup-kill-ring-interactive-insert
                      (numberp last-input-event)
-                     (= last-input-event ? ))
+                     (= last-input-event (string-to-char (kbd "C-g"))))
             (popup-kill-ring-clear-inserted)))))))
 
 (defun popup-kill-ring-pos-tip-show (str pos)
-  (when (eq window-system 'x)
+  (when (display-graphic-p)
     (pos-tip-show str popup-kill-ring-pos-tip-color pos nil 0 nil nil nil 0)))
 
 (defun popup-kill-ring-select ()
@@ -319,9 +357,9 @@ and `pos-tip.el'"
         ;; item of `popup-menu*' from inserted string to `current-buffer'.
         (unless (string= (buffer-substring (car p) (cdr p)) item)
           (delete-region (car p) (cdr p))
-          (return item)))
-      (return))
-    (return item)))
+          (cl-return item)))
+      (cl-return))
+    (cl-return item)))
 
 (defun popup-kill-ring-next ()
   (interactive)


### PR DESCRIPTION
This PR fixes problems I encountered when my installation of `popup.el` was upgraded ([commit](https://github.com/auto-complete/popup-el/commit/4036e5590a842390b12919473cb71654cae28783), `popup.el` changed to lexical scoping, which broke several things). It removes the `popup-kill-ring-kill-ring-show-func` functionality because I was unable to make it work with emacs 29.1 (still no clue about that, so I just pulled it until I figure it out). It also fixes a bug where isearch results sometimes displayed incorrectly.